### PR TITLE
Fix link to GitHub repository on website

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -85,7 +85,7 @@ export default defineConfigWithTheme<Config>({
     // },
 
     socialLinks: [
-      { icon: 'github', link: 'https://github.com/vuejs/' },
+      { icon: 'github', link: 'https://github.com/oumoussa98/vue3-infinite-loading' },
     ],
 
     footer: {


### PR DESCRIPTION
I found it hard to find this repository because this link (I think) wasn't going to the right place :-)