### PR TITLE
Fix a bug in InfiniteLoading.vue.

### DIFF
--- a/src/components/InfiniteLoading.vue
+++ b/src/components/InfiniteLoading.vue
@@ -52,6 +52,9 @@ const stateHandler: StateHandler = {
   complete() {
     state.value = "complete";
     observer?.disconnect();
+    const parentEl = params.parentEl || document.documentElement;
+    await nextTick();
+    if (top) parentEl.scrollTop = parentEl.scrollHeight - prevHeight;
   },
   error() {
     state.value = "error";


### PR DESCRIPTION
Fixes a bug in InfiniteLoading.vue that causes the final load to jump to the top of the elements when `top` is `true`. Resolves issue #70.