### PR TITLE
Add feature to manually load data with button

### DIFF
--- a/demo/src/App.vue
+++ b/demo/src/App.vue
@@ -16,6 +16,7 @@ let distance = ref(0);
 let top = ref(false);
 let comments = ref([]);
 let mountname = ref("Unmount");
+const manualload = ref(false);
 
 const displayMultipleLoader = () => {
   showLoaders.value = !showLoaders.value;
@@ -96,6 +97,9 @@ const load = async $state => {
       <Checkbox :checked="top" :disabled="!target" label="top" @click="topToggler">
         Top
       </Checkbox>
+      <Checkbox :checked="manualload" label="manual" @click="manualload = !manualload">
+        Manual Load
+      </Checkbox>
       <Checkbox :checked="target" label="target" @click="targetToggler">
         Target
       </Checkbox>
@@ -121,6 +125,7 @@ const load = async $state => {
       :distance="distance"
       :comments="comments"
       :identifier="resetData"
+      :manualload="manualload"
       :target="target"
       @infinite="load"
     />
@@ -129,6 +134,7 @@ const load = async $state => {
       :distance="distance"
       :comments="comments"
       :identifier="resetData"
+      :manualload="manualload"
       :target="target"
       @infinite="load"
     />

--- a/docs/api/props.md
+++ b/docs/api/props.md
@@ -35,6 +35,17 @@
 - **Details**:
   This property is used to specify weither you want the component to handle first load or not.
 
+## manualload
+
+- **Type**: `Boolean`
+- **Default**: `false`
+- **Details**:
+  When true, the component will not load data automatically on scroll. Instead, it will show a button to load more data using the slot `loadMore`.
+
+  This is usefull if you'd like the user to manually click a button to load the first set of data, which prevents the common issue where the user can't scroll to the footer of the page.
+
+  You can change this props at any time to enable or disable manual loading, for example within the load function.
+
 ## slots
 
 - **Type**: `Object`

--- a/docs/api/slots.md
+++ b/docs/api/slots.md
@@ -42,3 +42,19 @@
   <button @click="retry">Retry</button>
 </template>
 ```
+
+###
+
+## `loadMore`
+
+- **bind**: `loadMore` function
+- **Details**:
+  Used to create a custom button to load more data when `manualload` is set to `true`
+
+- **example**:
+
+```html
+<template #loadMore="{ load }">
+  <button @click="load">Load more</button>
+</template>
+```

--- a/src/components/InfiniteLoading.vue
+++ b/src/components/InfiniteLoading.vue
@@ -25,7 +25,7 @@ const { top, distance } = props;
 let { firstload } = props;
 const { identifier, target } = toRefs(props);
 
-let parentEl: HTMLElement | null = null;
+let parentEl: Element | null = null;
 
 function loadMore() {
   const parent = parentEl || document.documentElement;

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,15 +11,6 @@ export interface StateHandler {
   error: () => void;
 }
 
-export interface Params {
-  parentEl: Element | null;
-  distance: number;
-  top: boolean;
-  firstload: boolean;
-  infiniteLoading: Ref<HTMLDivElement | null>;
-  emit: () => void;
-}
-
 export interface Slots {
   complete?: string;
   error?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,5 +22,6 @@ export interface Props {
   distance?: number;
   identifier?: any;
   firstload?: boolean;
+  manualload?: boolean;
   slots?: Slots;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
 import { nextTick } from "vue";
 import type { Ref } from "vue";
-import type { Params, Target } from "./types";
+import type { Target } from "./types";
 
 function isVisible(el: Element, view: Element | null): boolean {
   const elRect = el.getBoundingClientRect();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,21 +15,4 @@ async function getParentEl(target: Ref<Target>): Promise<Element | null> {
   return target.value ? document.querySelector(target.value) : null;
 }
 
-function startObserver(params: Params) {
-  let rootMargin = `0px 0px ${params.distance}px 0px`;
-  if (params.top) rootMargin = `${params.distance}px 0px 0px 0px`;
-  const observer = new IntersectionObserver(
-    entries => {
-      const entry = entries[0];
-      if (entry.isIntersecting) {
-        if (params.firstload) params.emit();
-        params.firstload = true;
-      }
-    },
-    { root: params.parentEl, rootMargin }
-  );
-  observer.observe(params.infiniteLoading.value!);
-  return observer;
-}
-
-export { startObserver, isVisible, getParentEl };
+export { isVisible, getParentEl };


### PR DESCRIPTION
A common paradigm for infinite scroll is to require the user to click a load more button before infinite scrolling starts. This prevents an issue where somebody can never reach the footer of the website.

This pull requests adds a `manualload`  prop and `loadMore` slot. When `manualload` is true, the loadMore slot will be shown which contains a button to load more items. The user has to manually click the button in order to load more, instead of the infinite scroll automatically loading.

This prop has to be manually set which allows for different use cases. For example, within the load function you set `manualload` to false after the user clicks the button, enabling infinite scroll after the first click. Or you can keep it set to true, essentially turning the component into a load more button that handles all the state. 